### PR TITLE
Remove DEFINER value completely

### DIFF
--- a/fixture.class.php
+++ b/fixture.class.php
@@ -207,10 +207,9 @@ function getCreateQuery($row, $user, $domain) {
     else {
         $query = $row['Create View'];
         if($user) {
-            $definer = "`{$user}`@`{$domain}`";
             return preg_replace(
                 "/DEFINER=`(.*?)`@`(.*?)`/",
-                "DEFINER={$definer}",
+                "",
                 $query
             );
         }


### PR DESCRIPTION
* It turns out that the DEFINER value is more trouble than it's worth,
  since the username/host combinations lead to all manner of issues with
  permissions and security considerations that are difficult to
  disentangle.
  Rather than try to deal with all of them, just remove the definer, and
  have the view created by whatever MySQL user is used by Murphy when
  running the tests.
  This avoids all these issues, and makes the code somewhat simpler.